### PR TITLE
Enable dynamic input switching

### DIFF
--- a/services/inputflinger/EventHub.cpp
+++ b/services/inputflinger/EventHub.cpp
@@ -1358,19 +1358,6 @@ status_t EventHub::openDeviceLocked(const char *devicePath) {
         device->classes |= INPUT_DEVICE_CLASS_MIC;
     }
 
-    /*
-     * Maru: reserve bluetooth keyboards and mice for desktop
-     *
-     * TODO: add hook for dynamic switching
-     */
-    if (device->identifier.bus == BUS_BLUETOOTH
-            && (device->classes & (INPUT_DEVICE_CLASS_ALPHAKEY | INPUT_DEVICE_CLASS_CURSOR))) {
-        ALOGD("Reserving (dropping) device for Maru Desktop: id=%d, path='%s', name='%s'",
-                deviceId, devicePath, device->identifier.name.string());
-        delete device;
-        return -1;
-    }
-
     // Determine whether the device is external or internal.
     if (isExternalDeviceLocked(device)) {
         device->classes |= INPUT_DEVICE_CLASS_EXTERNAL;

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -91,6 +91,7 @@
 #include <configstore/Utils.h>
 
 #define DISPLAY_COUNT       1
+#define PROPERTY_MARUOS_DESKTOP_INTERACTIVE "sys.maruos.desktop.interactive"
 
 /*
  * DEBUG_SCREENSHOTS: set to true to check that screenshots are not all
@@ -1734,6 +1735,7 @@ void SurfaceFlinger::rebuildLayerStacks() {
         mVisibleRegionsDirty = false;
         invalidateHwcGeometry();
 
+        bool isDesktopInteractive = property_get_bool(PROPERTY_MARUOS_DESKTOP_INTERACTIVE, false);
         for (size_t dpy=0 ; dpy<mDisplays.size() ; dpy++) {
             Region opaqueRegion;
             Region dirtyRegion;
@@ -1745,7 +1747,10 @@ void SurfaceFlinger::rebuildLayerStacks() {
                 computeVisibleRegions(displayDevice, dirtyRegion, opaqueRegion);
 
                 mDrawingState.traverseInZOrder([&](Layer* layer) {
-                    if (layer->belongsToDisplay(displayDevice->getLayerStack(),
+                    // If linux is enable now, just omit cursor window layer.
+                    bool isCursorWindow = layer->isPotentialCursor();
+                    bool shouldShowLayer = !(isDesktopInteractive && isCursorWindow);
+                    if (shouldShowLayer && layer->belongsToDisplay(displayDevice->getLayerStack(),
                                 displayDevice->isPrimary())) {
                         Region drawRegion(tr.transform(
                                 layer->visibleNonTransparentRegion));


### PR DESCRIPTION
The `frameworks_native` part to enable dynamic input switching. For the whose view, please visit the issue [Enable dynamic input switching](https://github.com/maruos/maruos/issues/97).